### PR TITLE
Feat/film selection system

### DIFF
--- a/BDD/init/01-marsai.sql
+++ b/BDD/init/01-marsai.sql
@@ -1,7 +1,12 @@
 -- MarsAI Database Schema (Simplified)
--- Version: 2.0
--- Date: 2026-01-26
+-- Version: 2.2
+-- Date: 2026-03-04
 -- Description: Film festival platform with jury/admin validation system
+-- Changelog v2.2:
+--   - jury_assignments.status : ajout de la valeur 'passed' (film passe par le jury sans noter)
+-- Changelog v2.1: 
+--   - films.status : ajout de la valeur 'selected' (film selectionne par le jury)
+--   - film_categories : ajout de assigned_by et assigned_at (traçabilite de l'assignation)
 
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 START TRANSACTION;
@@ -120,7 +125,7 @@ CREATE TABLE `films` (
   `social_vimeo` varchar(255) DEFAULT NULL,
 
   -- Status and Tracking
-  `status` enum('pending', 'approved', 'rejected') DEFAULT 'pending',
+  `status` enum('pending', 'approved', 'rejected', 'selected') DEFAULT 'pending' COMMENT 'pending=soumis, approved=validé admin, rejected=rejeté, selected=sélectionné jury',
   `status_changed_at` datetime DEFAULT NULL,
   `status_changed_by` int DEFAULT NULL COMMENT 'User ID who changed the status',
   `rejection_reason` text COMMENT 'Reason for rejection (if rejected)',
@@ -138,16 +143,21 @@ CREATE TABLE `films` (
 
 -- --------------------------------------------------------
 -- Table: film_categories (Junction table)
+-- Assignee par le jury au moment de la selection d'un film (status = 'selected')
 -- --------------------------------------------------------
 
 DROP TABLE IF EXISTS `film_categories`;
 CREATE TABLE `film_categories` (
   `film_id` int NOT NULL,
   `category_id` int NOT NULL,
+  `assigned_by` int DEFAULT NULL COMMENT 'Jury member who assigned the category',
+  `assigned_at` datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'Date of category assignment',
   PRIMARY KEY (`film_id`, `category_id`),
   KEY `category_id` (`category_id`),
+  KEY `fk_fc_assigned_by` (`assigned_by`),
   CONSTRAINT `fk_fc_film` FOREIGN KEY (`film_id`) REFERENCES `films` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_fc_category` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_fc_category` FOREIGN KEY (`category_id`) REFERENCES `categories` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_fc_assigned_by` FOREIGN KEY (`assigned_by`) REFERENCES `users` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -303,7 +313,7 @@ CREATE TABLE `jury_assignments` (
   `list_id` int DEFAULT NULL COMMENT 'Jury list this assignment belongs to',
   `assigned_by` int NOT NULL COMMENT 'Super Jury who made the assignment',
   `assigned_at` datetime DEFAULT CURRENT_TIMESTAMP,
-  `status` enum('active','refused') NOT NULL DEFAULT 'active' COMMENT 'Assignment status',
+  `status` enum('active','refused','passed') NOT NULL DEFAULT 'active' COMMENT 'Assignment status: active=en cours, refused=refusé par jury, passed=passé sans noter',
   `refusal_reason` text DEFAULT NULL COMMENT 'Reason if jury refused the film',
   `refused_at` datetime DEFAULT NULL COMMENT 'Timestamp of refusal',
   PRIMARY KEY (`id`),

--- a/Front-end/src/components/FilmCard.jsx
+++ b/Front-end/src/components/FilmCard.jsx
@@ -23,7 +23,7 @@ function youtubeThumb(url) {
   return "";
 }
 
-export default function FilmCard({ film, apiUrl, imageVariant = "auto", rank }) {
+export default function FilmCard({ film, apiUrl, imageVariant = "auto", rank, onClick }) {
   const { t, lang } = useLanguage();
   const imgRef = useRef(null);
   const [imgStatus, setImgStatus] = useState("loading");
@@ -83,80 +83,92 @@ export default function FilmCard({ film, apiUrl, imageVariant = "auto", rank }) 
   const directorFirst = film?.director_firstname || t("filmCard.defaultFirstName");
   const directorLast = film?.director_lastname || t("filmCard.defaultLastName");
 
-  return (
-    <Link to={`/details-film/${film?.id ?? ""}`} className="block w-[260px] cursor-pointer">
-      <div className="group h-full flex flex-col">
-        <div className="relative w-full aspect-video rounded-lg overflow-hidden bg-[#C7C2CE]">
-          {imgStatus !== "loaded" && (
-            <div className="absolute inset-0 animate-pulse bg-[#C7C2CE]" />
-          )}
+  const inner = (
+    <div className="group h-full flex flex-col">
+      <div className="relative w-full aspect-video rounded-lg overflow-hidden bg-[#C7C2CE]">
+        {imgStatus !== "loaded" && (
+          <div className="absolute inset-0 animate-pulse bg-[#C7C2CE]" />
+        )}
 
-          <img
-            key={src}
-            ref={imgRef}
-            src={src}
-            alt={title}
-            className={`w-full h-full object-cover transition-transform duration-200 group-hover:scale-[1.03]
-              ${imgStatus === "loaded" ? "opacity-100" : "opacity-0"}`}
-            onLoad={() => setImgStatus("loaded")}
-            onError={() => {
-              if (fallback < sources.length - 1) {
-                setFallback((f) => f + 1);
-              } else {
-                setImgStatus("error");
-              }
-            }}
-            loading="eager"
-            decoding="async"
-          />
+        <img
+          key={src}
+          ref={imgRef}
+          src={src}
+          alt={title}
+          className={`w-full h-full object-cover transition-transform duration-200 group-hover:scale-[1.03]
+            ${imgStatus === "loaded" ? "opacity-100" : "opacity-0"}`}
+          onLoad={() => setImgStatus("loaded")}
+          onError={() => {
+            if (fallback < sources.length - 1) {
+              setFallback((f) => f + 1);
+            } else {
+              setImgStatus("error");
+            }
+          }}
+          loading="eager"
+          decoding="async"
+        />
 
-          {rank != null && (
-            <div
-              className={`absolute top-2 left-2 text-white text-sm font-bold w-8 h-8 rounded-full shadow-lg flex items-center justify-center z-10 bg-gradient-to-r ${
-                rank === 1
-                  ? "from-yellow-400 to-yellow-600"
-                  : rank === 2
-                  ? "from-gray-300 to-gray-500"
-                  : rank === 3
-                  ? "from-amber-600 to-amber-800"
-                  : "from-[#9a92c9] to-[#2f2a73]"
-              }`}
-            >
-              {rank}
-            </div>
-          )}
+        {rank != null && (
+          <div
+            className={`absolute top-2 left-2 text-white text-sm font-bold w-8 h-8 rounded-full shadow-lg flex items-center justify-center z-10 bg-gradient-to-r ${
+              rank === 1
+                ? "from-yellow-400 to-yellow-600"
+                : rank === 2
+                ? "from-gray-300 to-gray-500"
+                : rank === 3
+                ? "from-amber-600 to-amber-800"
+                : "from-[#9a92c9] to-[#2f2a73]"
+            }`}
+          >
+            {rank}
+          </div>
+        )}
 
-          {film?.user_rating !== null && film?.user_rating !== undefined && (
-            <div className="absolute top-2 right-2 bg-gradient-to-r from-[#9a92c9] to-[#2f2a73] text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg backdrop-blur-sm">
-              ⭐ {film.user_rating}/10
-            </div>
-          )}
+        {film?.user_rating !== null && film?.user_rating !== undefined && (
+          <div className="absolute top-2 right-2 bg-gradient-to-r from-[#9a92c9] to-[#2f2a73] text-white text-sm font-bold px-3 py-1 rounded-full shadow-lg backdrop-blur-sm">
+            ⭐ {film.user_rating}/10
+          </div>
+        )}
 
-          {imgStatus === "error" && (
-            <div className="absolute bottom-2 right-2 rounded-md bg-black/60 px-2 py-1 text-xs text-white">
-              {t("filmCard.imageUnavailable")}
-            </div>
-          )}
-        </div>
-
-        <p className="text-[#262335] mt-2 font-semibold">{title}</p>
-        <p className="text-sm text-[#262335]/80">
-          {directorFirst} {directorLast}
-        </p>
-
-        {film?.average_rating != null && (
-          <div className="flex items-center gap-2 mt-1">
-            <span className="text-sm font-bold text-[#463699]">{film.average_rating}/10</span>
-            {film.rating_count != null && (
-              <span className="text-xs text-[#262335]/50">
-                ({film.rating_count}{" "}
-                {film.rating_count !== 1 ? t("filmCard.votes") : t("filmCard.vote")}
-                )
-              </span>
-            )}
+        {imgStatus === "error" && (
+          <div className="absolute bottom-2 right-2 rounded-md bg-black/60 px-2 py-1 text-xs text-white">
+            {t("filmCard.imageUnavailable")}
           </div>
         )}
       </div>
+
+      <p className="text-[#262335] mt-2 font-semibold">{title}</p>
+      <p className="text-sm text-[#262335]/80">
+        {directorFirst} {directorLast}
+      </p>
+
+      {film?.average_rating != null && (
+        <div className="flex items-center gap-2 mt-1">
+          <span className="text-sm font-bold text-[#463699]">{film.average_rating}/10</span>
+          {film.rating_count != null && (
+            <span className="text-xs text-[#262335]/50">
+              ({film.rating_count}{" "}
+              {film.rating_count !== 1 ? t("filmCard.votes") : t("filmCard.vote")}
+              )
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (onClick) {
+    return (
+      <div onClick={onClick} className="block w-[260px] cursor-pointer">
+        {inner}
+      </div>
+    );
+  }
+
+  return (
+    <Link to={`/details-film/${film?.id ?? ""}`} className="block w-[260px] cursor-pointer">
+      {inner}
     </Link>
   );
 }

--- a/Front-end/src/i18n/en.js
+++ b/Front-end/src/i18n/en.js
@@ -157,6 +157,9 @@ export default {
     ratedLabel: "rated",
     unratedLabel: "unrated",
     completed: "completed",
+    selectButton: "Select",
+    passButton: "Pass",
+    alreadySelected: "Already selected",
   },
 
   profileSuperJury: {

--- a/Front-end/src/i18n/en.js
+++ b/Front-end/src/i18n/en.js
@@ -89,6 +89,7 @@ export default {
   },
 
   detailsFilm: {
+    backToFilms: "Back to my films",
     backToCatalog: "← Back to catalog",
     loading: "Loading…",
     error: "Error",
@@ -157,9 +158,6 @@ export default {
     ratedLabel: "rated",
     unratedLabel: "unrated",
     completed: "completed",
-    selectButton: "Select",
-    passButton: "Pass",
-    alreadySelected: "Already selected",
   },
 
   profileSuperJury: {

--- a/Front-end/src/i18n/fr.js
+++ b/Front-end/src/i18n/fr.js
@@ -89,6 +89,7 @@ export default {
   },
 
   detailsFilm: {
+    backToFilms: "Retour à mes films",
     backToCatalog: "← Retour aux catalogues",
     loading: "Chargement…",
     error: "Erreur",
@@ -158,9 +159,6 @@ export default {
     ratedLabel: "notés",
     unratedLabel: "non notés",
     completed: "terminé",
-    selectButton: "Sélectionner",
-    passButton: "Passer",
-    alreadySelected: "Déjà sélectionné",
   },
 
   profileSuperJury: {

--- a/Front-end/src/i18n/fr.js
+++ b/Front-end/src/i18n/fr.js
@@ -158,6 +158,9 @@ export default {
     ratedLabel: "notés",
     unratedLabel: "non notés",
     completed: "terminé",
+    selectButton: "Sélectionner",
+    passButton: "Passer",
+    alreadySelected: "Déjà sélectionné",
   },
 
   profileSuperJury: {

--- a/Front-end/src/pages/Catalogs.jsx
+++ b/Front-end/src/pages/Catalogs.jsx
@@ -42,7 +42,7 @@ export default function Catalogs() {
     setError("");
 
     try {
-      const res = await fetch(`${API_URL}/api/films?all=1`);
+      const res = await fetch(`${API_URL}/api/films?all=1&status=selected`);
       const data = await res.json();
 
       if (!res.ok) {
@@ -127,9 +127,6 @@ export default function Catalogs() {
   // --- FILTRAGE FINAL ---
   const filteredFilms = useMemo(() => {
     return films.filter((film) => {
-      if (filters.selected === "selected" && film.status !== "selected")
-        return false;
-
       if (filters.rated) {
         const r = rankingMap.get(film.id);
         if (!r || r.average_rating === null) return false;

--- a/Front-end/src/pages/DetailsFilm.jsx
+++ b/Front-end/src/pages/DetailsFilm.jsx
@@ -32,222 +32,6 @@ function withAuthHeaders(headers = {}) {
   return token ? { ...headers, Authorization: `Bearer ${token}` } : headers;
 }
 
-function ReviewForm({ rating, comment, onRatingChange, onCommentChange }) {
-  const { t } = useLanguage();
-  return (
-    <div className="mt-12 flex flex-col gap-10 md:flex-row items-end mb-[69px]">
-      <div className="md:flex-1">
-        <h2 className="mb-4 text-[28px] font-medium text-[#262335]">
-          {t("detailsFilm.giveOpinion")}
-        </h2>
-
-        <div className="w-full max-w-[600px] h-[80px] flex items-center justify-between px-[27px] bg-black/10 border border-[#262335]/10 rounded-md">
-          {Array.from({ length: 10 }).map((_, i) => {
-            const value = i + 1;
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => onRatingChange(value)}
-                className="w-10 h-10 p-0 border-0 bg-transparent flex items-center justify-center focus:outline-none"
-              >
-                <svg
-                  className={`w-8 h-8 ${
-                    value <= rating ? "text-yellow-400" : "text-gray-300"
-                  }`}
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.97a1 1 0 00.95.69h4.178c.969 0 1.371 1.24.588 1.81l-3.38 2.455a1 1 0 00-.364 1.118l1.287 3.97c.3.921-.755 1.688-1.54 1.118l-3.381-2.455a1 1 0 00-1.175 0l-3.38 2.455c-.785.57-1.84-.197-1.54-1.118l1.286-3.97a1 1 0 00-.364-1.118L2.049 9.397c-.783-.57-.38-1.81.588-1.81h4.178a1 1 0 00.95.69l1.286-3.97z" />
-                </svg>
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="md:flex-1">
-        <h2 className="mb-4 text-[28px] font-medium text-[#262335]">
-          {t("detailsFilm.addComment")}
-        </h2>
-
-        <div className="w-full max-w-[600px] h-[80px] p-[3px] bg-white border border-black/10">
-          <textarea
-            name="comment"
-            value={comment}
-            onChange={(e) => onCommentChange(e.target.value)}
-            placeholder={t("detailsFilm.commentPlaceholder")}
-            className="w-full h-full bg-black/5 border border-black/10 outline-none resize-none px-4 py-4 text-base text-[#262335] placeholder:text-[#262335]/40"
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const STATUS_STYLES = {
-  pending: {
-    bg: "bg-yellow-100",
-    text: "text-yellow-800",
-    border: "border-yellow-300",
-  },
-  approved: {
-    bg: "bg-green-100",
-    text: "text-green-800",
-    border: "border-green-300",
-  },
-  rejected: { bg: "bg-red-100", text: "text-red-800", border: "border-red-300" },
-};
-
-const STATUS_LABEL_KEYS = {
-  pending: "detailsFilm.statusPending",
-  approved: "detailsFilm.statusApproved",
-  rejected: "detailsFilm.statusRejected",
-};
-
-function StatusBadge({ filmStatus }) {
-  const { t } = useLanguage();
-  const cfg = STATUS_STYLES[filmStatus] || STATUS_STYLES.pending;
-  const labelKey = STATUS_LABEL_KEYS[filmStatus] || STATUS_LABEL_KEYS.pending;
-  return (
-    <span
-      className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${cfg.bg} ${cfg.text} ${cfg.border}`}
-    >
-      {t(labelKey)}
-    </span>
-  );
-}
-
-function ApprovalPanel({
-  filmStatus,
-  rejectionReason,
-  onReasonChange,
-  onApprove,
-  onReject,
-  updating,
-  statusMessage,
-}) {
-  const [showRejectForm, setShowRejectForm] = useState(false);
-  const { t } = useLanguage();
-
-  return (
-    <div className="mt-8 rounded-xl border border-[#262335]/15 bg-[#f8f6f3] p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-[#262335]">
-          {t("detailsFilm.filmManagement")}
-        </h3>
-        <StatusBadge filmStatus={filmStatus} />
-      </div>
-
-      {statusMessage && (
-        <div
-          className={`mb-4 rounded-lg px-4 py-3 text-sm font-medium ${
-            statusMessage.type === "success"
-              ? "bg-green-50 text-green-700 border border-green-200"
-              : "bg-red-50 text-red-700 border border-red-200"
-          }`}
-        >
-          {statusMessage.text}
-        </div>
-      )}
-
-      {!showRejectForm ? (
-        <div className="flex flex-wrap gap-3">
-          {filmStatus !== "approved" && (
-            <button
-              onClick={onApprove}
-              disabled={updating}
-              className="px-5 py-2 rounded-lg bg-green-600 text-white font-medium hover:bg-green-700 disabled:opacity-50 transition-colors"
-            >
-              {updating ? t("detailsFilm.updating") : t("detailsFilm.approve")}
-            </button>
-          )}
-          {filmStatus !== "rejected" && (
-            <button
-              onClick={() => setShowRejectForm(true)}
-              disabled={updating}
-              className="px-5 py-2 rounded-lg bg-red-600 text-white font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
-            >
-              {t("detailsFilm.reject")}
-            </button>
-          )}
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <label className="block text-sm font-medium text-[#262335]">
-            {t("detailsFilm.rejectionLabel")}
-          </label>
-          <textarea
-            value={rejectionReason}
-            onChange={(e) => onReasonChange(e.target.value)}
-            rows={3}
-            placeholder={t("detailsFilm.rejectionPlaceholder")}
-            className="w-full rounded-lg border border-[#262335]/20 bg-white px-4 py-3 text-[#262335] placeholder:text-[#262335]/40 outline-none focus:ring-2 focus:ring-red-300 resize-none"
-          />
-          <div className="flex gap-3">
-            <button
-              onClick={onReject}
-              disabled={updating || !rejectionReason.trim()}
-              className="px-5 py-2 rounded-lg bg-red-600 text-white font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
-            >
-              {updating ? t("detailsFilm.sending") : t("detailsFilm.confirmReject")}
-            </button>
-            <button
-              onClick={() => {
-                setShowRejectForm(false);
-                onReasonChange("");
-              }}
-              disabled={updating}
-              className="px-5 py-2 rounded-lg border border-[#262335]/20 text-[#262335] font-medium hover:bg-black/5 transition-colors"
-            >
-              {t("detailsFilm.cancel")}
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SaveButton({
-  onSave,
-  saving,
-  saveSuccess,
-  saveError,
-  onNextFilm,
-  hasNextFilm,
-  hasVoted,
-}) {
-  const { t } = useLanguage();
-  return (
-    <div className="mt-4 flex flex-wrap items-center gap-4 mb-8">
-      <button
-        onClick={onSave}
-        disabled={saving}
-        className="px-6 py-2 rounded-md bg-[#262335] text-white disabled:opacity-50"
-      >
-        {saving ? t("detailsFilm.saving") : t("detailsFilm.save")}
-      </button>
-
-      {hasVoted && hasNextFilm && (
-        <button
-          onClick={onNextFilm}
-          className="px-6 py-2 rounded-md bg-[#463699] text-white hover:bg-[#362b7a] transition-colors"
-        >
-          Film suivant →
-        </button>
-      )}
-
-      {saveSuccess && (
-        <span className="text-green-600 text-sm font-medium">
-          {t("detailsFilm.saved")}
-        </span>
-      )}
-      {saveError && <span className="text-red-600 text-sm">{saveError}</span>}
-    </div>
-  );
-}
-
 export default function DetailsFilm() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -295,31 +79,17 @@ export default function DetailsFilm() {
     [API_URL]
   );
 
-  const fetchFilmsPage = useCallback(
-    async (page, limit, signal) => {
-      const res = await fetch(`${API_URL}/api/films?page=${page}&limit=${limit}`, {
+  const fetchSelectedFilms = useCallback(
+    async (signal) => {
+      const res = await fetch(`${API_URL}/api/films?all=1&status=selected`, {
         signal,
         headers: withAuthHeaders(),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.message || "Erreur films");
-      return { items: data.data || [], pagination: data.pagination };
+      return data.data || [];
     },
     [API_URL]
-  );
-
-  const fetchAllFilms = useCallback(
-    async (signal) => {
-      const first = await fetchFilmsPage(1, 50, signal);
-      const all = [...first.items];
-      const totalPages = first.pagination?.totalPages || 1;
-      for (let p = 2; p <= totalPages; p++) {
-        const next = await fetchFilmsPage(p, 50, signal);
-        all.push(...next.items);
-      }
-      return all;
-    },
-    [fetchFilmsPage]
   );
 
   const fetchMyRatings = useCallback(
@@ -377,7 +147,7 @@ export default function DetailsFilm() {
     (async () => {
       try {
         const [allFilms, filmData] = await Promise.all([
-          fetchAllFilms(controller.signal),
+          fetchSelectedFilms(controller.signal),
           fetchFilmById(id, controller.signal),
         ]);
 
@@ -466,7 +236,7 @@ export default function DetailsFilm() {
     canReview,
     isJury,
     API_URL,
-    fetchAllFilms,
+    fetchSelectedFilms,
     fetchFilmById,
     fetchMyRatings,
     fetchFilmStats,
@@ -636,220 +406,132 @@ export default function DetailsFilm() {
   );
 
   return (
-    <div className="bg-white">
-      <div
-        className="
-          mx-auto max-w-7xl
-          px-4 sm:px-6
-          lg:pl-8 lg:pr-16
-          py-8 sm:py-10
-        "
-      >
+    <div className="bg-[#FBF5F0] min-h-screen">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 sm:py-10">
+
+        {/* Retour */}
         <div className="mb-6">
           <Link
             to={isJury ? "/profile-jury" : "/catalogs"}
-            className="text-[#262335]/70 hover:text-[#262335]"
+            className="text-[#262335]/60 hover:text-[#262335] text-sm transition-colors"
           >
-            ← {isJury ? "Retour à mes films" : "Retour aux catalogues"}
+            ← {isJury ? t("detailsFilm.backToFilms") : t("detailsFilm.backToCatalog")}
           </Link>
         </div>
 
-        {status === "loading" && <div className="text-[#262335]">Chargement…</div>}
+        {/* Chargement */}
+        {status === "loading" && (
+          <div className="flex flex-col gap-6 lg:flex-row lg:gap-10">
+            <div className="lg:flex-[2] space-y-4">
+              <div className="w-full aspect-video rounded-xl bg-[#262335]/10 animate-pulse" />
+              <div className="h-6 bg-[#262335]/10 rounded w-1/2 animate-pulse" />
+              <div className="h-4 bg-[#262335]/10 rounded w-1/3 animate-pulse" />
+              <div className="space-y-2">
+                <div className="h-4 bg-[#262335]/10 rounded animate-pulse" />
+                <div className="h-4 bg-[#262335]/10 rounded animate-pulse" />
+                <div className="h-4 bg-[#262335]/10 rounded w-3/4 animate-pulse" />
+              </div>
+            </div>
+            <div className="lg:w-[300px] lg:shrink-0 space-y-4">
+              {[0,1,2].map(i => (
+                <div key={i} className="flex gap-3">
+                  <div className="w-[120px] h-[70px] rounded-lg bg-[#262335]/10 animate-pulse shrink-0" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 bg-[#262335]/10 rounded animate-pulse" />
+                    <div className="h-3 bg-[#262335]/10 rounded w-3/4 animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
+        {/* Erreur */}
         {status === "error" && (
           <div className="rounded-xl border border-red-200 bg-red-50 p-4">
             <p className="text-red-700 font-medium">Erreur : {error}</p>
           </div>
         )}
 
+        {/* Succès */}
         {status === "success" && (
-          <div className="flex flex-col gap-10 lg:flex-row lg:gap-16">
+          <div className="flex flex-col gap-10 lg:flex-row lg:gap-12">
+
+            {/* ── Colonne principale ── */}
             <div className="min-w-0 lg:flex-[2]">
-              <div className="lg:hidden">
-                <div className="w-full max-w-[387px] mx-auto">
-                  <div className="w-full aspect-video">
-                    <FilmPlayer
-                      title={title}
-                      aiUrl={aiUrl}
-                      thumbnailUrl={film?.thumbnail_stream_url || film?.thumbnail_url}
-                      posterUrl={film?.poster_stream_url || film?.poster_url}
-                      apiUrl={API_URL}
-                    />
-                  </div>
 
-                  <div className="mt-6">
-                    <p className="text-[24px] font-semibold text-[#262335] leading-tight">
-                      {title}
-                    </p>
-
-                    <div className="mt-4 flex items-center justify-between gap-6">
-                      <div className="min-w-0 flex items-center gap-4">
-                        <div className="w-[56px] h-[56px] shrink-0 rounded-full bg-black/10 border border-[#262335]/10 overflow-hidden">
-                          <img
-                            src={posterUrl}
-                            alt={director}
-                            className="w-full h-full object-cover"
-                            onError={(e) => (e.currentTarget.src = "/placeholder.jpg")}
-                          />
-                        </div>
-                        <p className="text-[16px] font-medium text-[#262335] truncate">
-                          {director}
-                        </p>
-                      </div>
-                      <p className="shrink-0 text-[16px] font-medium text-[#262335]">
-                        {views}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="mt-6">
-                    <p className="text-[16px] font-medium text-[#262335]">
-                      {published ? `Publié le ${published}` : "Date de publication"}
-                    </p>
-                    <p className="mt-3 max-w-[80ch] text-[16px] text-[#262335]/80 leading-relaxed whitespace-pre-line">
-                      {description}
-                    </p>
-                  </div>
-
-                  {canReview && (
-                    <ApprovalPanel
-                      filmStatus={filmStatus}
-                      rejectionReason={rejectionReason}
-                      onReasonChange={setRejectionReason}
-                      onApprove={() => handleStatusChange("approved")}
-                      onReject={() => handleStatusChange("rejected")}
-                      updating={statusUpdating}
-                      statusMessage={statusMessage}
-                    />
-                  )}
-
-                  {canReview && filmStatus === "approved" && (
-                    <>
-                      <ReviewForm
-                        rating={rating}
-                        comment={comment}
-                        onRatingChange={setRating}
-                        onCommentChange={setComment}
-                      />
-                      <SaveButton
-                        onSave={saveRating}
-                        saving={saving}
-                        saveSuccess={saveSuccess}
-                        saveError={saveError}
-                        hasNextFilm={!!nextFilmId}
-                        hasVoted={!!ratingId || saveSuccess}
-                        onNextFilm={() => navigate(`/details-film/${nextFilmId}`)}
-                      />
-                    </>
-                  )}
-
-                  {canReview && filmStatus === "approved" && <JurySection compact />}
-                </div>
-              </div>
-
-              <div className="hidden lg:block">
-                <div className="w-full rounded-[18px] overflow-hidden">
-                  <div className="w-full aspect-video">
-                    <FilmPlayer
-                      title={title}
-                      aiUrl={aiUrl}
-                      thumbnailUrl={film?.thumbnail_stream_url || film?.thumbnail_url}
-                      posterUrl={film?.poster_stream_url || film?.poster_url}
-                      apiUrl={API_URL}
-                    />
-                  </div>
-                </div>
-
-                <div className="mt-6 flex items-start justify-between gap-6">
-                  <div className="min-w-0">
-                    <p className="text-lg font-medium">{title}</p>
-                    <div className="mt-4 flex items-center gap-4">
-                      <p className="text-lg font-medium truncate">{director}</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="mt-6">
-                  <p className="text-base font-medium text-[#262335]">
-                    {published ? `Publié le ${published}` : "Date de publication"}
-                  </p>
-                  <p className="mt-3 max-w-[80ch] text-base text-[#262335]/80 leading-relaxed whitespace-pre-line">
-                    {description}
-                  </p>
-                </div>
-
-                {canReview && (
-                  <ApprovalPanel
-                    filmStatus={filmStatus}
-                    rejectionReason={rejectionReason}
-                    onReasonChange={setRejectionReason}
-                    onApprove={() => handleStatusChange("approved")}
-                    onReject={() => handleStatusChange("rejected")}
-                    updating={statusUpdating}
-                    statusMessage={statusMessage}
+              {/* Lecteur vidéo */}
+              <div className="w-full rounded-xl overflow-hidden shadow-md">
+                <div className="w-full aspect-video">
+                  <FilmPlayer
+                    title={title}
+                    aiUrl={aiUrl}
+                    thumbnailUrl={film?.thumbnail_stream_url || film?.thumbnail_url}
+                    posterUrl={film?.poster_stream_url || film?.poster_url}
+                    apiUrl={API_URL}
                   />
-                )}
-
-                {canReview && filmStatus === "approved" && (
-                  <>
-                    <ReviewForm
-                      rating={rating}
-                      comment={comment}
-                      onRatingChange={setRating}
-                      onCommentChange={setComment}
-                    />
-                    <SaveButton
-                      onSave={saveRating}
-                      saving={saving}
-                      saveSuccess={saveSuccess}
-                      saveError={saveError}
-                      hasNextFilm={!!nextFilmId}
-                      hasVoted={!!ratingId || saveSuccess}
-                      onNextFilm={() => navigate(`/details-film/${nextFilmId}`)}
-                    />
-                  </>
-                )}
-
-                {canReview && filmStatus === "approved" && <JurySection />}
+                </div>
               </div>
+
+              {/* Titre */}
+              <h1 className="mt-5 text-xl sm:text-2xl font-semibold text-[#262335] leading-tight">
+                {title}
+              </h1>
+
+              {/* Réalisateur + pays */}
+              <div className="mt-4 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="min-w-0">
+                    <p className="text-[15px] font-semibold text-[#262335] truncate">
+                      {film?.director_firstname} {film?.director_lastname}
+                    </p>
+                    {film?.country && (
+                      <p className="text-xs text-[#262335]/50">{film.country}</p>
+                    )}
+                  </div>
+                </div>
+                {film?.director_school && (
+                  <p className="shrink-0 text-sm text-[#262335]/60 italic">{film.director_school}</p>
+                )}
+              </div>
+
+              {/* Date + description */}
+              <div className="mt-5 border-t border-[#262335]/10 pt-5">
+                {published && (
+                  <p className="text-sm font-medium text-[#262335]/60 mb-3">
+                    Publié le {published}
+                  </p>
+                )}
+                <p className="text-[15px] text-[#262335]/80 leading-relaxed whitespace-pre-line max-w-[75ch]">
+                  {description}
+                </p>
+              </div>
+
+              {/* Outils IA */}
+              {film?.ai_tools_used && (
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {film.ai_tools_used.split(",").map((tool) => tool.trim()).filter(Boolean).map((tool) => (
+                    <span key={tool} className="text-xs px-3 py-1 rounded-full bg-[#463699]/10 text-[#463699] font-medium">
+                      {tool}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+
             </div>
 
-            {!isJury && (
-              <aside
-                className="
-                  w-full
-                  max-w-[300px]
-                  mx-auto
-                  pt-2
-                  space-y-5
-                  lg:w-[300px]
-                  lg:shrink-0
-                  lg:mx-0
-                "
-              >
+            {/* ── Suggestions ── */}
+            {suggestions.length > 0 && (
+              <aside className="w-full lg:w-[260px] lg:shrink-0 pt-0 lg:pt-2 flex flex-row lg:flex-col gap-6 lg:gap-8 overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0">
                 {suggestions.map((s) => (
-                  <div
-                    key={`sug-${id}-${s.id}`}
-                    className="
-                      max-w-[260px]
-                      mx-auto
-                      [&>a]:w-full
-                      [&_.relative]:aspect-video
-                      [&_.relative]:h-auto
-                      [&_img]:h-full
-                      [&_img]:w-full
-                      [&_img]:object-cover
-                      [&_p:first-of-type]:text-[14px]
-                      [&_p:first-of-type]:leading-snug
-                      [&_p:last-of-type]:text-[12px]
-                      [&_p:first-of-type]:mt-1
-                    "
-                  >
-                    <FilmCard film={s} apiUrl={API_URL} imageVariant="thumbnail" />
+                  <div key={`sug-${id}-${s.id}`} className="shrink-0 lg:shrink">
+                    <FilmCard film={s} apiUrl={API_URL} imageVariant="auto" />
                   </div>
                 ))}
               </aside>
             )}
+
           </div>
         )}
       </div>

--- a/Front-end/src/pages/Home.jsx
+++ b/Front-end/src/pages/Home.jsx
@@ -86,7 +86,7 @@ export default function Home() {
 
   // ✅ Randomize 3 films on each page load
   useEffect(() => {
-    fetch(`${API_URL}/api/films?all=1`)
+    fetch(`${API_URL}/api/films?all=1&status=selected`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data?.success && Array.isArray(data.data)) {

--- a/Front-end/src/pages/ProfileJury.jsx
+++ b/Front-end/src/pages/ProfileJury.jsx
@@ -82,10 +82,10 @@ function RefuseModal({ film, onClose, onConfirm, t }) {
   );
 }
 
-function FilmRow({ film, apiUrl, onRefuse, t }) {
+function FilmRow({ film, apiUrl, onRefuse, onSelect, t }) {
   return (
     <div className="flex items-center gap-4 p-3 bg-white rounded-xl border border-[#262335]/5 hover:border-[#463699]/30 transition-colors">
-      <a href={`/details-film/${film?.id ?? ""}`} className="shrink-0 w-24 h-14 rounded-lg overflow-hidden bg-[#C7C2CE]">
+      <button type="button" onClick={() => onSelect(film)} className="shrink-0 w-24 h-14 rounded-lg overflow-hidden bg-[#C7C2CE]">
         <img
           src={
             film?.thumbnail_url
@@ -100,15 +100,15 @@ function FilmRow({ film, apiUrl, onRefuse, t }) {
             e.target.src = "/placeholder.jpg";
           }}
         />
-      </a>
+      </button>
 
-      <a href={`/details-film/${film?.id ?? ""}`} className="flex-1 min-w-0">
+      <button type="button" onClick={() => onSelect(film)} className="flex-1 min-w-0 text-left">
         <p className="font-semibold text-[#262335] truncate">{film?.title}</p>
         <p className="text-sm text-[#262335]/70 truncate">
           {film?.director_firstname} {film?.director_lastname}
           {film?.country && <span className="ml-2 text-[#262335]/50">({film.country})</span>}
         </p>
-      </a>
+      </button>
 
       <div className="flex items-center gap-3 shrink-0">
         {film?.user_rating !== null && film?.user_rating !== undefined ? (
@@ -127,6 +127,109 @@ function FilmRow({ film, apiUrl, onRefuse, t }) {
         {film?.average_rating != null && (
           <span className="text-sm font-bold text-[#463699]">{film.average_rating}/10</span>
         )}
+      </div>
+    </div>
+  );
+}
+
+
+function FilmModal({ film, apiUrl, onClose, onSelect, onPass, t }) {
+  const [selecting, setSelecting] = useState(false);
+  const [error, setError] = useState("");
+
+  const posterSrc = film?.poster_url
+    ? film.poster_url.startsWith("http")
+      ? film.poster_url
+      : `${apiUrl}${film.poster_url}`
+    : "/placeholder.jpg";
+
+  const youtubeEmbed = film?.youtube_url
+    ? film.youtube_url.replace("watch?v=", "embed/").replace("youtu.be/", "www.youtube.com/embed/")
+    : null;
+
+  const handleSelect = async () => {
+    setSelecting(true);
+    setError("");
+    try {
+      const token = localStorage.getItem("token");
+      const res = await fetch(`${apiUrl}/api/jury/films/${film.id}/select`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(data?.message || "Erreur");
+      onSelect();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSelecting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-[#FBF5F0] rounded-2xl max-w-2xl w-full shadow-2xl overflow-hidden max-h-[90vh] flex flex-col">
+        {/* Video / Poster */}
+        <div className="relative w-full aspect-video bg-black shrink-0">
+          {youtubeEmbed ? (
+            <iframe
+              src={youtubeEmbed}
+              title={film?.title}
+              className="w-full h-full"
+              allowFullScreen
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            />
+          ) : (
+            <img src={posterSrc} alt={film?.title} className="w-full h-full object-cover" />
+          )}
+          <button
+            onClick={onClose}
+            className="absolute top-3 right-3 bg-black/60 hover:bg-black/80 text-white rounded-full w-8 h-8 flex items-center justify-center text-lg transition-colors"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 overflow-y-auto flex flex-col gap-4">
+          <div>
+            <h2 className="text-2xl font-bold text-[#262335] mb-1">{film?.title}</h2>
+            <p className="text-[#463699] font-medium">
+              {film?.director_firstname} {film?.director_lastname}
+              {film?.country && <span className="text-[#262335]/50 font-normal ml-2">— {film.country}</span>}
+            </p>
+          </div>
+
+          {film?.description && (
+            <p className="text-[#262335]/80 text-sm leading-relaxed line-clamp-5">{film.description}</p>
+          )}
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          {/* Action buttons */}
+          <div className="flex gap-3 pt-2">
+            <button
+              onClick={handleSelect}
+              disabled={selecting || film?.status === "selected"}
+              className="flex-1 py-3 rounded-xl bg-gradient-to-r from-[#463699] to-[#2f2a73] text-white font-bold hover:opacity-90 disabled:opacity-50 transition-opacity"
+            >
+              {selecting
+                ? "..."
+                : film?.status === "selected"
+                ? t("profileJury.alreadySelected") || "Déjà sélectionné"
+                : t("profileJury.selectButton") || "Sélectionner"}
+            </button>
+            <button
+              onClick={onPass}
+              className="flex-1 py-3 rounded-xl border-2 border-[#262335]/20 text-[#262335] font-bold hover:bg-[#262335]/5 transition-colors"
+            >
+              {t("profileJury.passButton") || "Passer"}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -153,6 +256,8 @@ export default function ProfileJury() {
   const [page, setPage] = useState(1);
 
   const [refuseTarget, setRefuseTarget] = useState(null);
+  const [selectTarget, setSelectTarget] = useState(null);
+
 
   const [stats, setStats] = useState({
     totalAssigned: 0,
@@ -273,6 +378,19 @@ export default function ProfileJury() {
   const onRefuseConfirm = () => {
     setRefuseTarget(null);
     if (view.type === "films") fetchFilms(page, view.listId);
+  };
+
+  const onSelectConfirm = () => {
+    if (selectTarget) {
+      setFilms((prev) => prev.filter((f) => f.id !== selectTarget.id));
+      setStats((prev) => ({
+        ...prev,
+        totalAssigned: Math.max(0, prev.totalAssigned - 1),
+        totalUnrated: selectTarget.user_rating == null ? Math.max(0, prev.totalUnrated - 1) : prev.totalUnrated,
+        totalRated: selectTarget.user_rating != null ? Math.max(0, prev.totalRated - 1) : prev.totalRated,
+      }));
+    }
+    setSelectTarget(null);
   };
 
   if (profileLoading) {
@@ -478,19 +596,13 @@ export default function ProfileJury() {
               {uiState === "success" && viewMode === "grid" && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-y-12 justify-items-center">
                   {films.map((film) => (
-                    <div key={film.id} className="flex flex-col items-center w-[260px]">
-                      <FilmCard film={film} apiUrl={API_URL} />
-                      {!film.user_rating && (
-                        <button
-                          onClick={(e) => {
-                            e.preventDefault();
-                            setRefuseTarget(film);
-                          }}
-                          className="mt-2 text-sm text-red-600 hover:text-red-800 font-medium transition-colors"
-                        >
-                          {t("profileJury.refuseButton")}
-                        </button>
-                      )}
+                    <div
+                      key={film.id}
+                      className={`flex flex-col items-center w-[260px] transition-opacity duration-300 ${
+                        film.is_passed ? "opacity-35 grayscale pointer-events-none" : ""
+                      }`}
+                    >
+                      <FilmCard film={film} apiUrl={API_URL} onClick={() => !film.is_passed && setSelectTarget(film)} />
                     </div>
                   ))}
                 </div>
@@ -499,7 +611,14 @@ export default function ProfileJury() {
               {uiState === "success" && viewMode === "list" && (
                 <div className="flex flex-col gap-2">
                   {films.map((film) => (
-                    <FilmRow key={film.id} film={film} apiUrl={API_URL} onRefuse={setRefuseTarget} t={t} />
+                    <div
+                      key={film.id}
+                      className={`transition-opacity duration-300 ${
+                        film.is_passed ? "opacity-35 grayscale pointer-events-none" : ""
+                      }`}
+                    >
+                      <FilmRow film={film} apiUrl={API_URL} onRefuse={setRefuseTarget} onSelect={setSelectTarget} t={t} />
+                    </div>
                   ))}
                 </div>
               )}
@@ -543,6 +662,37 @@ export default function ProfileJury() {
 
       {refuseTarget && (
         <RefuseModal film={refuseTarget} onClose={() => setRefuseTarget(null)} onConfirm={onRefuseConfirm} t={t} />
+      )}
+
+      {selectTarget && (
+        <FilmModal
+          film={selectTarget}
+          apiUrl={API_URL}
+          onClose={() => setSelectTarget(null)}
+          onSelect={onSelectConfirm}
+          onPass={async () => {
+            if (selectTarget) {
+              try {
+                const token = localStorage.getItem("token");
+                await fetch(`${API_URL}/api/jury/films/${selectTarget.id}/pass`, {
+                  method: "POST",
+                  headers: { Authorization: `Bearer ${token}` },
+                });
+              } catch (err) {
+                console.error("passFilm error:", err);
+              }
+              setFilms((prev) =>
+                prev.map((f) => f.id === selectTarget.id ? { ...f, is_passed: true } : f)
+              );
+              setStats((prev) => ({
+                ...prev,
+                totalUnrated: selectTarget.user_rating == null ? Math.max(0, prev.totalUnrated - 1) : prev.totalUnrated,
+              }));
+            }
+            setSelectTarget(null);
+          }}
+          t={t}
+        />
       )}
     </div>
   );

--- a/back-end/src/controllers/film.controller.js
+++ b/back-end/src/controllers/film.controller.js
@@ -237,7 +237,7 @@ export const updateFilmStatus = async (req, res) => {
     }
 
     const newStatus = (status || "").trim();
-    if (!newStatus || !["pending", "approved", "rejected"].includes(newStatus)) {
+    if (!newStatus || !["pending", "approved", "rejected", "selected"].includes(newStatus)) {
       return res.status(400).json({ success: false, message: "Statut invalide" });
     }
 

--- a/back-end/src/controllers/film.controller.js
+++ b/back-end/src/controllers/film.controller.js
@@ -305,12 +305,16 @@ export const getFilms = async (req, res) => {
     const sortField = req.query.sortField || "created_at";
     const sortOrder = req.query.sortOrder || "DESC";
 
+    const allowedStatuses = ["approved", "selected", "pending", "rejected"];
+    const requestedStatus = req.query.status || "approved";
+    const safeStatus = allowedStatuses.includes(requestedStatus) ? requestedStatus : "approved";
+
     const { rows, count } = await Film.findAll({
       limit,
       offset,
       sortField,
       sortOrder,
-      status: "approved",
+      status: safeStatus,
     });
 
     const signedRows = await Promise.all(rows.map(withSignedMedia));

--- a/back-end/src/controllers/jury.controller.js
+++ b/back-end/src/controllers/jury.controller.js
@@ -221,3 +221,54 @@ export const refuseFilm = async (req, res) => {
     });
   }
 };
+
+// Select a film (Jury only)
+export const selectFilm = async (req, res) => {
+  try {
+    const filmId = parseInt(req.params.id, 10);
+    if (!filmId) {
+      return res.status(400).json({ success: false, message: "Invalid film ID" });
+    }
+
+    const userId = req.user.userId;
+    const film = await Film.selectFilm(filmId, userId);
+
+    return res.status(200).json({
+      success: true,
+      message: "Film s\u00e9lectionn\u00e9 avec succ\u00e8s",
+      data: film,
+    });
+  } catch (err) {
+    console.error("selectFilm error:", err);
+    return res.status(400).json({
+      success: false,
+      message: err.message || "Erreur lors de la s\u00e9lection du film",
+    });
+  }
+};
+
+// Pass a film (jury skips it, persisted in DB)
+export const passFilm = async (req, res) => {
+  try {
+    const filmId = parseInt(req.params.id, 10);
+    if (!filmId) {
+      return res.status(400).json({ success: false, message: "Invalid film ID" });
+    }
+
+    const userId = req.user.userId;
+    const result = await JuryAssignment.pass(userId, filmId);
+
+    if (!result) {
+      return res.status(404).json({ success: false, message: "Ce film ne vous est pas assigné" });
+    }
+
+    if (result.alreadyPassed) {
+      return res.status(409).json({ success: false, message: "Vous avez déjà passé ce film" });
+    }
+
+    return res.status(200).json({ success: true, message: "Film passé avec succès" });
+  } catch (err) {
+    console.error("passFilm error:", err);
+    return res.status(500).json({ success: false, message: err.message || "Erreur lors du passage du film" });
+  }
+};

--- a/back-end/src/models/Film.js
+++ b/back-end/src/models/Film.js
@@ -180,6 +180,24 @@ export default class Film {
     return { ...film, status, rejection_reason: rejectionReason };
   }
 
+
+  static async selectFilm(filmId, userId) {
+    const film = await this.findById(filmId);
+    if (!film) throw new Error("Film non trouv\u00e9");
+
+    if (film.status !== "approved") {
+      throw new Error(`Impossible de s\u00e9lectionner un film avec le statut : ${film.status}`);
+    }
+
+    const sql = `
+      UPDATE films
+      SET status = 'selected', status_changed_at = NOW(), status_changed_by = ?
+      WHERE id = ?
+    `;
+    await db.query(sql, [userId, filmId]);
+    return { ...film, status: "selected" };
+  }
+
   static async getStats() {
     const [statusRows] = await db.query(
       `SELECT status, COUNT(*) as count FROM films GROUP BY status`

--- a/back-end/src/models/JuryAssignment.js
+++ b/back-end/src/models/JuryAssignment.js
@@ -44,6 +44,7 @@ export default class JuryAssignment {
         ja.assigned_at,
         ja.status AS assignment_status,
         ja.refusal_reason,
+        (ja.status = 'passed') AS is_passed,
 
         jr.rating   AS user_rating,
         jr.comment  AS user_comment,
@@ -59,7 +60,8 @@ export default class JuryAssignment {
       LEFT JOIN jury_ratings jr_all
         ON jr_all.film_id = f.id
       WHERE ja.jury_id = ?
-        AND ja.status = 'active'
+        AND ja.status IN ('active', 'passed')
+        AND f.status != 'selected'
         ${listFilter}
       GROUP BY
         f.id,
@@ -88,11 +90,13 @@ export default class JuryAssignment {
       SELECT
         COUNT(*) AS total_assigned,
         SUM(CASE WHEN ja.status = 'refused' THEN 1 ELSE 0 END) AS total_refused,
-        SUM(CASE WHEN ja.status = 'active' AND jr.id IS NULL THEN 1 ELSE 0 END) AS total_unrated,
-        SUM(CASE WHEN ja.status = 'active' AND jr.id IS NOT NULL THEN 1 ELSE 0 END) AS total_rated
+        SUM(CASE WHEN ja.status = 'passed' THEN 1 ELSE 0 END) AS total_passed,
+        SUM(CASE WHEN ja.status IN ('active', 'passed') AND jr.id IS NULL THEN 1 ELSE 0 END) AS total_unrated,
+        SUM(CASE WHEN ja.status IN ('active', 'passed') AND jr.id IS NOT NULL THEN 1 ELSE 0 END) AS total_rated
       FROM jury_assignments ja
       LEFT JOIN jury_ratings jr
         ON jr.film_id = ja.film_id AND jr.user_id = ?
+      INNER JOIN films f ON f.id = ja.film_id AND f.status != 'selected'
       WHERE ja.jury_id = ?
         ${listFilter}
     `;
@@ -117,6 +121,24 @@ export default class JuryAssignment {
        SET status = 'refused', refusal_reason = ?, refused_at = NOW()
        WHERE jury_id = ? AND film_id = ?`,
       [reason, juryId, filmId]
+    );
+
+    return { success: true };
+  }
+
+  // Pass a film (jury skips it without rating)
+  static async pass(juryId, filmId) {
+    const [existing] = await db.query(
+      "SELECT id, status FROM jury_assignments WHERE jury_id = ? AND film_id = ?",
+      [juryId, filmId]
+    );
+
+    if (!existing.length) return null;
+    if (existing[0].status === "passed") return { alreadyPassed: true };
+
+    await db.query(
+      `UPDATE jury_assignments SET status = 'passed' WHERE jury_id = ? AND film_id = ?`,
+      [juryId, filmId]
     );
 
     return { success: true };

--- a/back-end/src/routes/jury.routes.js
+++ b/back-end/src/routes/jury.routes.js
@@ -10,6 +10,8 @@ import {
   getAssignedFilmsForJury,
   getResults,
   refuseFilm,
+  selectFilm,
+  passFilm,
 } from "../controllers/jury.controller.js";
 import { getMyLists } from "../controllers/jurylist.controller.js";
 
@@ -47,5 +49,11 @@ router.delete("/films/:id/rate", deleteRating);
 
 // Refuse an assigned film
 router.post("/films/:id/refuse", refuseFilm);
+
+// Select a film (Jury)
+router.post("/films/:id/select", selectFilm);
+
+// Pass a film (Jury skips without rating)
+router.post("/films/:id/pass", passFilm);
 
 export default router;


### PR DESCRIPTION
This pull request introduces several important updates to both the database schema and the front-end and back-end logic of the film festival platform. The main focus is to support a new "selected" status for films (indicating jury selection), enhance jury workflow (including the ability to "pass" on films), and improve the traceability of category assignments. Additionally, the UI is updated to support these changes, including new modal workflows for jury actions.

**Database schema updates:**

- **Film status and jury workflow:**
  * Added a new `selected` status to the `films.status` enum to represent films selected by the jury.
  * Updated the `jury_assignments.status` enum to include a `passed` value, allowing jury members to pass on films without rating them.

- **Category assignment traceability:**
  * Enhanced the `film_categories` table by adding `assigned_by` (jury member ID) and `assigned_at` (timestamp) columns, with appropriate foreign key constraints, to track who assigned a film to a category and when.

**Back-end logic updates:**

- **Film status handling:**
  * Updated the film status validation in the API to allow the new `selected` status.
  * Modified the films API to accept a `status` query parameter (with validation), allowing filtering by `selected` status as well as others.

**Front-end/UI updates:**

- **Catalog and home page filtering:**
  * Updated the `Catalogs` and `Home` pages to fetch and display only films with the `selected` status. [[1]](diffhunk://#diff-3a7ce6340f9f6fa739c502de03845880bc704c9d2af5829ebc6e07cf2bcf8868L45-R45) [[2]](diffhunk://#diff-b7cb15707498e5720a28830a868e8a9296c3ecf7285d406b92f47f8057afe08fL89-R89)
  * Removed redundant client-side filtering for selected films, as it is now handled server-side.

- **Jury workflow enhancements:**
  * Added a modal (`FilmModal`) for jury members to select or pass on a film, including API integration and UI feedback. [[1]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dR135-R237) [[2]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dR666-R696)
  * Updated film row and card components to support click-to-select and visual feedback for passed films (e.g., grayed out, non-interactive). [[1]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dL85-R88) [[2]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dL481-R605) [[3]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dL502-R621)
  * Adjusted jury statistics and film lists in response to selection and pass actions.

- **Internationalization:**
  * Added new translation keys for "Back to my films" in both English and French. [[1]](diffhunk://#diff-3c4df8d9ec37decbd4e55f5ab89bb38ca0829be7f48e524f0a5feacfe9ed52fbR92) [[2]](diffhunk://#diff-64ef3b7b206366d01f291fa3bef0f9a0d90508cb206c6b2f24df3037dc1002a5R92)

---

**Database schema updates:**

- Added `selected` to `films.status` and `passed` to `jury_assignments.status` enums to support new jury workflows. [[1]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L123-R128) [[2]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L306-R316)
- Enhanced `film_categories` with `assigned_by` and `assigned_at` columns, including foreign key constraints for traceability.

**Back-end logic updates:**

- Allowed `selected` status in film status validation and enabled API filtering by status (including `selected`). [[1]](diffhunk://#diff-a98048fa6127f461cb21fdaace4718778152447a6bf757069a20792b9630c465L240-R240) [[2]](diffhunk://#diff-a98048fa6127f461cb21fdaace4718778152447a6bf757069a20792b9630c465R308-R317)

**Front-end/UI updates:**

- Updated catalog and home pages to show only films with `selected` status, removing redundant filtering. [[1]](diffhunk://#diff-3a7ce6340f9f6fa739c502de03845880bc704c9d2af5829ebc6e07cf2bcf8868L45-R45) [[2]](diffhunk://#diff-b7cb15707498e5720a28830a868e8a9296c3ecf7285d406b92f47f8057afe08fL89-R89) [[3]](diffhunk://#diff-3a7ce6340f9f6fa739c502de03845880bc704c9d2af5829ebc6e07cf2bcf8868L130-L132)
- Implemented modal and workflow for jury members to select or pass on films, updating UI and statistics accordingly. [[1]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dR135-R237) [[2]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dR666-R696) [[3]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dL481-R605) [[4]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dL502-R621) [[5]](diffhunk://#diff-0947683d9a46efa7e7570f297d41bb975678ac70d29d865681009f6f4ac07e5dR383-R395)
- Added new translation keys for improved internationalization. [[1]](diffhunk://#diff-3c4df8d9ec37decbd4e55f5ab89bb38ca0829be7f48e524f0a5feacfe9ed52fbR92) [[2]](diffhunk://#diff-64ef3b7b206366d01f291fa3bef0f9a0d90508cb206c6b2f24df3037dc1002a5R92)