### PR TITLE
feat(database): update partners table to include logo URL and key for Scaleway object storage

### DIFF
--- a/BDD/init/01-marsai.sql
+++ b/BDD/init/01-marsai.sql
@@ -3,12 +3,11 @@
 -- Date: 2026-03-05
 -- Description: Film festival platform with jury/admin validation system
 -- Changelog v2.3:
---   - partners.logo remplacé par logo_key (Scaleway Object Storage key)
---   - users.profile_picture remplacé par profile_picture_key (Scaleway Object Storage key)
---   - Logique : stocker uniquement la key, générer la signed URL côté backend
+--   - partners.logo_key : ajout de la clé objet Scaleway pour suppression
+--   - users.profile_picture_key : ajout de la clé objet Scaleway pour suppression
 -- Changelog v2.2:
 --   - jury_assignments.status : ajout de la valeur 'passed' (film passe par le jury sans noter)
--- Changelog v2.1:
+-- Changelog v2.1: 
 --   - films.status : ajout de la valeur 'selected' (film selectionne par le jury)
 --   - film_categories : ajout de assigned_by et assigned_at (traçabilite de l'assignation)
 
@@ -53,7 +52,8 @@ CREATE TABLE `users` (
   `email` varchar(100) NOT NULL,
   `password` varchar(255) NOT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
-  `profile_picture_key` varchar(500) DEFAULT NULL COMMENT 'Scaleway Object Storage key (ex: users/profile-abc.jpg)',
+  `profile_picture` varchar(500) DEFAULT NULL COMMENT 'URL photo de profil Scaleway (obligatoire pour jury)',
+  `profile_picture_key` varchar(500) DEFAULT NULL COMMENT 'Clé objet Scaleway pour suppression',
   `role_title` varchar(255) DEFAULT NULL COMMENT 'Fonction du jury (ex: CHERCHEUSE IA / OPENAI)',
   `bio` text DEFAULT NULL COMMENT 'Description du membre du jury (optionnel)',
   PRIMARY KEY (`id`),
@@ -109,10 +109,10 @@ CREATE TABLE `films` (
   `country` varchar(100) DEFAULT NULL COMMENT 'Country of origin',
   `description` text COMMENT 'Original description in the director''s language',
   `description_english` text COMMENT 'English description for international audiences',
-  `film_url` varchar(500) DEFAULT NULL COMMENT 'Scaleway Object Storage key (ex: films/film-abc.mp4)',
+  `film_url` varchar(500) DEFAULT NULL COMMENT 'URL to uploaded film file',
   `youtube_url` varchar(500) DEFAULT NULL COMMENT 'YouTube video URL for public viewing',
-  `poster_url` varchar(500) DEFAULT NULL COMMENT 'Scaleway Object Storage key (ex: films/poster-abc.jpg)',
-  `thumbnail_url` varchar(500) DEFAULT NULL COMMENT 'Scaleway Object Storage key (ex: films/thumb-abc.jpg)',
+  `poster_url` varchar(500) DEFAULT NULL COMMENT 'Main poster image',
+  `thumbnail_url` varchar(500) DEFAULT NULL COMMENT 'Small thumbnail for lists',
   `ai_tools_used` text COMMENT 'AI tools used (free text)',
   `ai_certification` tinyint(1) DEFAULT 0 COMMENT 'Certifies film was made with AI tools',
   `classification` varchar(50) DEFAULT NULL COMMENT 'Classification du film, ex: G, PG, PG-13, R',
@@ -316,7 +316,7 @@ CREATE TABLE `jury_assignments` (
   `list_id` int DEFAULT NULL COMMENT 'Jury list this assignment belongs to',
   `assigned_by` int NOT NULL COMMENT 'Super Jury who made the assignment',
   `assigned_at` datetime DEFAULT CURRENT_TIMESTAMP,
-  `status` enum('active','refused','passed') NOT NULL DEFAULT 'active' COMMENT 'active=en cours, refused=refusé par jury, passed=passé sans noter',
+  `status` enum('active','refused','passed') NOT NULL DEFAULT 'active' COMMENT 'Assignment status: active=en cours, refused=refusé par jury, passed=passé sans noter',
   `refusal_reason` text DEFAULT NULL COMMENT 'Reason if jury refused the film',
   `refused_at` datetime DEFAULT NULL COMMENT 'Timestamp of refusal',
   PRIMARY KEY (`id`),
@@ -380,7 +380,7 @@ CREATE TABLE `invitations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
--- Table: site_pages
+-- Table: site_pages (CMS-like editable page content)
 -- --------------------------------------------------------
 
 DROP TABLE IF EXISTS `site_pages`;
@@ -449,30 +449,6 @@ INSERT INTO `site_pages` (`slug`, `content_fr`, `content_en`) VALUES
 ));
 
 -- --------------------------------------------------------
--- Table: partners
--- --------------------------------------------------------
-
-DROP TABLE IF EXISTS `partners`;
-CREATE TABLE `partners` (
-  `id` INT NOT NULL AUTO_INCREMENT,
-  `name` VARCHAR(255) NOT NULL,
-  `logo_key` VARCHAR(500) NOT NULL COMMENT 'Scaleway Object Storage key (ex: partners/logo-abc.png)',
-  `url` VARCHAR(500) NOT NULL,
-  `display_order` INT DEFAULT 0,
-  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  INDEX `idx_display_order` (`display_order`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-
-INSERT INTO `partners` (`name`, `logo_key`, `url`, `display_order`) VALUES
-('La Plateforme', 'partners/logo-laplateforme.png', 'https://laplateforme.io', 1),
-('Ville de Marseille', 'partners/logo-marseille.png', 'https://marseille.fr', 2),
-('Région Sud', 'partners/logo-regionsud.png', 'https://maregionsud.fr', 3),
-('OpenAI', 'partners/logo-openai.png', 'https://openai.com', 4),
-('Anthropic', 'partners/logo-anthropic.png', 'https://anthropic.com', 5);
-
--- --------------------------------------------------------
 -- Sample films for testing
 -- --------------------------------------------------------
 
@@ -491,6 +467,7 @@ SELECT
     u.id,
     u.name,
     u.email,
+    u.profile_picture,
     u.profile_picture_key,
     u.role_title,
     u.bio,
@@ -499,6 +476,31 @@ FROM users u
 INNER JOIN user_roles ur ON u.id = ur.user_id
 WHERE ur.role_id = 1
 ORDER BY u.name ASC;
+
+-- --------------------------------------------------------
+-- Table: partners
+-- --------------------------------------------------------
+
+DROP TABLE IF EXISTS `partners`;
+CREATE TABLE `partners` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(255) NOT NULL,
+  `logo` VARCHAR(500) NOT NULL COMMENT 'URL publique Scaleway du logo',
+  `logo_key` VARCHAR(500) DEFAULT NULL COMMENT 'Clé objet Scaleway pour suppression',
+  `url` VARCHAR(500) NOT NULL,
+  `display_order` INT DEFAULT 0,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  INDEX `idx_display_order` (`display_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO `partners` (`name`, `logo`, `url`, `display_order`) VALUES
+('La Plateforme', 'https://via.placeholder.com/200x80/463699/ffffff?text=La+Plateforme', 'https://laplateforme.io', 1),
+('Ville de Marseille', 'https://via.placeholder.com/200x80/8A83DA/ffffff?text=Marseille', 'https://marseille.fr', 2),
+('Région Sud', 'https://via.placeholder.com/200x80/C7C2CE/262335?text=Region+Sud', 'https://maregionsud.fr', 3),
+('OpenAI', 'https://via.placeholder.com/200x80/FBD5BD/262335?text=OpenAI', 'https://openai.com', 4),
+('Anthropic', 'https://via.placeholder.com/200x80/FBF5F0/262335?text=Anthropic', 'https://anthropic.com', 5);
 
 COMMIT;
 


### PR DESCRIPTION
This pull request updates the database schema and seed data for the film festival platform, mainly to clarify the storage and usage of media URLs and object keys for users, films, and partners. It also improves comments and documentation for better maintainability. The most important changes are grouped below.

**Media URL and Object Key Handling**

* The `users` table now separates the public profile picture URL (`profile_picture`) from the object storage key (`profile_picture_key`), making it clearer which field is used for display and which for backend operations. (`[[1]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L56-R56)`, `[[2]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07R470)`)
* The `films` table updates comments and usage for media fields (`film_url`, `poster_url`, `thumbnail_url`) to clarify that these are public URLs, not object storage keys. (`[BDD/init/01-marsai.sqlL112-R115](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L112-R115)`)
* The `partners` table is redefined: it now includes both a public logo URL (`logo`) and an object storage key (`logo_key`), and the seed data uses placeholder image URLs for partner logos. (`[[1]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L451-L474)`, `[[2]](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07R480-R504)`)

**Documentation and Comments**

* Changelog and table comments are revised to clarify the distinction between public URLs and object storage keys, with explanations for their intended usage (display vs. deletion). (`[BDD/init/01-marsai.sqlL6-R7](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L6-R7)`)
* Table documentation for `site_pages` is improved to note its CMS-like editable content purpose. (`[BDD/init/01-marsai.sqlL383-R383](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L383-R383)`)
* The `jury_assignments.status` field comment is updated for clarity on assignment status meanings. (`[BDD/init/01-marsai.sqlL319-R319](diffhunk://#diff-4e97e2a836743c10b33aa6b411a832af4fcd17bb9f9001806a1384bd2c3dae07L319-R319)`)