### PR TITLE
feat(prize-list): enhance UI with podium display and star rating component

### DIFF
--- a/Front-end/src/pages/PrizeList.jsx
+++ b/Front-end/src/pages/PrizeList.jsx
@@ -1,14 +1,161 @@
 import { useEffect, useState } from "react";
 import { useLanguage } from "../context/LanguageContext";
-import { FaTrophy } from "react-icons/fa";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5001";
 
-const RANK_STYLES = {
-  1: "bg-yellow-400 text-yellow-900",
-  2: "bg-gray-300 text-gray-800",
-  3: "bg-amber-600 text-amber-100",
+const MEDAL = {
+  1: { emoji: "🥇", bg: "bg-yellow-400", text: "text-yellow-900", bar: "bg-yellow-400", label: "GOLD" },
+  2: { emoji: "🥈", bg: "bg-gray-300", text: "text-gray-800", bar: "bg-gray-300", label: "SILVER" },
+  3: { emoji: "🥉", bg: "bg-amber-600", text: "text-amber-100", bar: "bg-amber-600", label: "BRONZE" },
 };
+
+function StarRating({ value, max = 10 }) {
+  const pct = Math.round((value / max) * 100);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative h-1.5 w-20 rounded-full bg-[#262335]/10 overflow-hidden">
+        <div
+          className="absolute left-0 top-0 h-full rounded-full bg-[#463699] transition-all duration-700"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="font-black text-[#463699] text-lg tabular-nums">
+        {value.toFixed(1)}
+        <span className="text-xs font-normal text-[#262335]/30">/10</span>
+      </span>
+    </div>
+  );
+}
+
+function PodiumCard({ film, index }) {
+  const medal = MEDAL[film.rank] || {};
+  const isFirst = film.rank === 1;
+
+  return (
+    <div
+      className={`relative flex flex-col items-center text-center ${
+        isFirst ? "md:-translate-y-6 z-10" : ""
+      }`}
+      style={{ animation: `fadeUp 0.5s ease ${index * 0.12}s both` }}
+    >
+      {/* Rank badge */}
+      <div
+        className={`w-14 h-14 rounded-full flex items-center justify-center text-2xl mb-4 shadow-lg ${medal.bg} ${medal.text}`}
+      >
+        {medal.emoji}
+      </div>
+
+      {/* Card */}
+      <div
+        className={`w-full bg-white rounded-2xl overflow-hidden shadow-md border-2 ${
+          isFirst ? "border-yellow-400 shadow-yellow-200/60 shadow-xl" : "border-transparent"
+        }`}
+      >
+        {film.thumbnail_url ? (
+          <div className="relative h-40 overflow-hidden">
+            <img
+              src={`${API_URL}${film.thumbnail_url}`}
+              alt={film.title}
+              className="w-full h-full object-cover"
+              onError={(e) => { e.target.parentElement.style.display = "none"; }}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-[#262335]/60 to-transparent" />
+          </div>
+        ) : (
+          <div className="h-40 bg-[#262335]/5 flex items-center justify-center text-5xl">🎬</div>
+        )}
+
+        <div className="p-4">
+          <p className="font-black text-[#262335] text-base leading-snug mb-1 uppercase tracking-tight">
+            {film.title}
+          </p>
+          <p className="text-xs text-[#262335]/50 mb-3">{film.director} · {film.country}</p>
+          {film.average_rating !== null ? (
+            <StarRating value={film.average_rating} />
+          ) : null}
+          <p className="text-xs text-[#262335]/30 mt-2">{film.rating_count} votes</p>
+        </div>
+      </div>
+
+      {/* Podium step */}
+      <div
+        className={`w-full mt-3 rounded-b-xl flex items-center justify-center font-black tracking-widest text-xs py-2 ${medal.bg} ${medal.text}`}
+        style={{ minHeight: isFirst ? 56 : film.rank === 2 ? 40 : 28 }}
+      >
+        {medal.label}
+      </div>
+    </div>
+  );
+}
+
+function TableRow({ film, index }) {
+  const medal = MEDAL[film.rank];
+
+  return (
+    <tr
+      className="border-b border-[#262335]/5 hover:bg-[#463699]/4 transition-colors group"
+      style={{ animation: `fadeUp 0.4s ease ${index * 0.04}s both` }}
+    >
+      {/* Rank */}
+      <td className="py-4 px-5 text-center w-16">
+        {medal ? (
+          <span
+            className={`inline-flex items-center justify-center w-9 h-9 rounded-full font-black text-sm ${medal.bg} ${medal.text}`}
+          >
+            {film.rank}
+          </span>
+        ) : (
+          <span className="text-[#262335]/30 font-bold text-sm tabular-nums">{film.rank}</span>
+        )}
+      </td>
+
+      {/* Film */}
+      <td className="py-4 px-4">
+        <div className="flex items-center gap-3">
+          {film.thumbnail_url ? (
+            <div className="w-14 h-9 rounded overflow-hidden flex-shrink-0">
+              <img
+                src={`${API_URL}${film.thumbnail_url}`}
+                alt={film.title}
+                className="w-full h-full object-cover"
+                onError={(e) => { e.target.parentElement.style.display = "none"; }}
+              />
+            </div>
+          ) : (
+            <div className="w-14 h-9 rounded bg-[#262335]/5 flex items-center justify-center text-lg flex-shrink-0">🎬</div>
+          )}
+          <span className="font-black text-[#262335] uppercase tracking-tight text-sm group-hover:text-[#463699] transition-colors">
+            {film.title}
+          </span>
+        </div>
+      </td>
+
+      {/* Director */}
+      <td className="py-4 px-4 text-sm text-[#262335]/60 hidden md:table-cell">{film.director}</td>
+
+      {/* Country */}
+      <td className="py-4 px-4 hidden lg:table-cell">
+        <span className="text-xs font-bold bg-[#262335]/6 text-[#262335]/60 px-2 py-1 rounded-full">
+          {film.country}
+        </span>
+      </td>
+
+      {/* Rating */}
+      <td className="py-4 px-4 text-center">
+        {film.average_rating !== null ? (
+          <StarRating value={film.average_rating} />
+        ) : (
+          <span className="text-xs text-[#262335]/20 italic">—</span>
+        )}
+      </td>
+
+      {/* Votes */}
+      <td className="py-4 px-5 text-center">
+        <span className="text-xs font-bold text-[#262335]/40 tabular-nums">{film.rating_count}</span>
+      </td>
+    </tr>
+  );
+}
 
 export default function PrizeList() {
   const { t } = useLanguage();
@@ -26,7 +173,6 @@ export default function PrizeList() {
         if (!res.ok) throw new Error(json?.message || "Error");
         setRanking(json.data || []);
       } catch (err) {
-        console.error("Ranking error:", err);
         setError(err.message);
       } finally {
         setLoading(false);
@@ -35,121 +181,152 @@ export default function PrizeList() {
     fetchRanking();
   }, []);
 
+  const top3 = ranking.filter((f) => f.rank <= 3).sort((a, b) => {
+    // order: 2, 1, 3 for visual podium
+    const order = { 1: 1, 2: 0, 3: 2 };
+    return order[a.rank] - order[b.rank];
+  });
+  const rest = ranking.filter((f) => f.rank > 3);
+
   return (
-    <div className="bg-[#FBF5F0] min-h-screen">
-      <div className="max-w-5xl mx-auto px-4 py-10 md:py-14">
-        {/* Header */}
-        <div className="text-center mb-10">
-          <h1 className="text-3xl md:text-4xl font-bold text-[#262335] flex items-center justify-center gap-3">
-            <FaTrophy className="text-yellow-500" />
-            {t("prizeList.title")}
-          </h1>
-        </div>
+    <>
+      <style>{`
+        @keyframes fadeUp {
+          from { opacity: 0; transform: translateY(20px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes shimmer {
+          0%   { background-position: -400px 0; }
+          100% { background-position: 400px 0; }
+        }
+        .skeleton {
+          background: linear-gradient(90deg, #262335/8 25%, #262335/15 50%, #262335/8 75%);
+          background-size: 800px 100%;
+          animation: shimmer 1.4s infinite;
+        }
+      `}</style>
 
-        {/* Loading */}
-        {loading && (
-          <div className="text-center py-16">
-            <div className="inline-block w-10 h-10 border-4 border-[#262335]/20 border-t-[#463699] rounded-full animate-spin mb-4" />
-            <p className="text-[#262335]/60">{t("prizeList.loading")}</p>
+      <div className="bg-[#FBF5F0] min-h-screen">
+        <div className="max-w-5xl mx-auto px-4 py-12 md:py-20">
+
+          {/* ── HEADER ── */}
+          <div className="mb-14" style={{ animation: "fadeUp 0.5s ease both" }}>
+            <p className="text-xs font-black tracking-[0.3em] text-[#463699] uppercase mb-3">
+              Festival MarsAi
+            </p>
+            <h1 className="text-5xl md:text-6xl font-black text-[#262335] uppercase tracking-tighter italic leading-none">
+              {t("prizeList.title")}
+            </h1>
+            <div className="mt-4 h-1 w-16 bg-[#463699] rounded-full" />
           </div>
-        )}
 
-        {/* Error */}
-        {!loading && error && (
-          <div className="text-center py-16">
-            <p className="text-red-500 font-medium">{t("prizeList.error")}</p>
-          </div>
-        )}
-
-        {/* Empty */}
-        {!loading && !error && ranking.length === 0 && (
-          <div className="text-center py-16">
-            <p className="text-xl font-semibold text-[#262335]/60 mb-2">{t("prizeList.noResults")}</p>
-            <p className="text-[#262335]/40">{t("prizeList.noResultsDesc")}</p>
-          </div>
-        )}
-
-        {/* Ranking table */}
-        {!loading && !error && ranking.length > 0 && (
-          <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
-            {/* Desktop table */}
-            <div className="hidden md:block overflow-x-auto">
-              <table className="w-full text-left text-sm">
-                <thead>
-                  <tr className="border-b-2 border-[#262335]/10 bg-[#262335] text-white">
-                    <th className="py-4 px-4 font-bold text-center w-16">{t("prizeList.rank")}</th>
-                    <th className="py-4 px-4 font-bold">{t("prizeList.film")}</th>
-                    <th className="py-4 px-4 font-bold">{t("prizeList.director")}</th>
-                    <th className="py-4 px-4 font-bold">{t("prizeList.country")}</th>
-                    <th className="py-4 px-4 font-bold text-center">{t("prizeList.averageRating")}</th>
-                    <th className="py-4 px-4 font-bold text-center">{t("prizeList.votes")}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {ranking.map((film) => (
-                    <tr key={film.film_id} className="border-b border-[#262335]/5 hover:bg-[#463699]/5 transition-colors">
-                      <td className="py-4 px-4 text-center">
-                        <span className={`inline-flex items-center justify-center w-8 h-8 rounded-full font-bold text-sm ${RANK_STYLES[film.rank] || "bg-[#262335]/10 text-[#262335]"}`}>
-                          {film.rank}
-                        </span>
-                      </td>
-                      <td className="py-4 px-4">
-                        <div className="flex items-center gap-3">
-                          {film.thumbnail_url && (
-                            <img
-                              src={`${API_URL}${film.thumbnail_url}`}
-                              alt={film.title}
-                              className="w-12 h-8 object-cover rounded"
-                              onError={(e) => { e.target.style.display = "none"; }}
-                            />
-                          )}
-                          <span className="font-semibold text-[#262335]">{film.title}</span>
-                        </div>
-                      </td>
-                      <td className="py-4 px-4 text-[#262335]/70">{film.director}</td>
-                      <td className="py-4 px-4 text-[#262335]/70">{film.country}</td>
-                      <td className="py-4 px-4 text-center">
-                        {film.average_rating !== null ? (
-                          <span className="font-bold text-[#463699] text-lg">{film.average_rating.toFixed(1)}<span className="text-xs text-[#262335]/40">/10</span></span>
-                        ) : (
-                          <span className="text-[#262335]/30 text-xs italic">{t("prizeList.noRating")}</span>
-                        )}
-                      </td>
-                      <td className="py-4 px-4 text-center">
-                        <span className="bg-[#262335]/10 text-[#262335] text-xs font-bold px-3 py-1 rounded-full">{film.rating_count}</span>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+          {/* ── LOADING ── */}
+          {loading && (
+            <div className="text-center py-20">
+              <div className="inline-block w-10 h-10 border-4 border-[#262335]/10 border-t-[#463699] rounded-full animate-spin mb-4" />
+              <p className="text-sm text-[#262335]/40 tracking-widest uppercase">{t("prizeList.loading")}</p>
             </div>
+          )}
 
-            {/* Mobile cards */}
-            <div className="md:hidden divide-y divide-[#262335]/5">
-              {ranking.map((film) => (
-                <div key={film.film_id} className="p-4 flex items-start gap-3">
-                  <span className={`flex-shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-full font-bold text-sm ${RANK_STYLES[film.rank] || "bg-[#262335]/10 text-[#262335]"}`}>
-                    {film.rank}
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <p className="font-semibold text-[#262335] truncate">{film.title}</p>
-                    <p className="text-sm text-[#262335]/60">{film.director}</p>
-                    {film.country && <p className="text-xs text-[#262335]/40">{film.country}</p>}
-                  </div>
-                  <div className="text-right flex-shrink-0">
-                    {film.average_rating !== null ? (
-                      <p className="font-bold text-[#463699]">{film.average_rating.toFixed(1)}<span className="text-xs text-[#262335]/40">/10</span></p>
-                    ) : (
-                      <p className="text-xs text-[#262335]/30 italic">{t("prizeList.noRating")}</p>
-                    )}
-                    <p className="text-xs text-[#262335]/40">{film.rating_count} {t("prizeList.votes").toLowerCase()}</p>
+          {/* ── ERROR ── */}
+          {!loading && error && (
+            <div className="text-center py-20">
+              <div className="text-5xl mb-4">⚠️</div>
+              <p className="font-black text-red-500 uppercase">{t("prizeList.error")}</p>
+            </div>
+          )}
+
+          {/* ── EMPTY ── */}
+          {!loading && !error && ranking.length === 0 && (
+            <div className="text-center py-24 border-2 border-dashed border-[#262335]/10 rounded-3xl">
+              <div className="text-6xl mb-4 opacity-20">🏆</div>
+              <p className="text-xl font-black text-[#262335]/40 uppercase tracking-tight">
+                {t("prizeList.noResults")}
+              </p>
+              <p className="text-sm text-[#262335]/30 mt-2">{t("prizeList.noResultsDesc")}</p>
+            </div>
+          )}
+
+          {/* ── CONTENT ── */}
+          {!loading && !error && ranking.length > 0 && (
+            <>
+              {/* PODIUM TOP 3 */}
+              {top3.length > 0 && (
+                <div className="mb-16">
+                  <p className="text-xs font-black tracking-[0.25em] text-[#262335]/30 uppercase mb-8">
+                    — Podium
+                  </p>
+                  <div className="grid grid-cols-3 gap-4 md:gap-6 items-end max-w-2xl mx-auto">
+                    {top3.map((film, i) => (
+                      <PodiumCard key={film.film_id} film={film} index={i} />
+                    ))}
                   </div>
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
+              )}
+
+              {/* REST TABLE */}
+              {rest.length > 0 && (
+                <div>
+                  <p className="text-xs font-black tracking-[0.25em] text-[#262335]/30 uppercase mb-6">
+                    — Classement complet
+                  </p>
+                  <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-left text-sm">
+                        <thead>
+                          <tr className="bg-[#262335] text-white">
+                            <th className="py-4 px-5 font-black text-center w-16 text-xs tracking-widest uppercase">#</th>
+                            <th className="py-4 px-4 font-black text-xs tracking-widest uppercase">{t("prizeList.film")}</th>
+                            <th className="py-4 px-4 font-black text-xs tracking-widest uppercase hidden md:table-cell">{t("prizeList.director")}</th>
+                            <th className="py-4 px-4 font-black text-xs tracking-widest uppercase hidden lg:table-cell">{t("prizeList.country")}</th>
+                            <th className="py-4 px-4 font-black text-xs tracking-widest uppercase">{t("prizeList.averageRating")}</th>
+                            <th className="py-4 px-5 font-black text-xs tracking-widest uppercase text-center">{t("prizeList.votes")}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {rest.map((film, i) => (
+                            <TableRow key={film.film_id} film={film} index={i} />
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Mobile cards for rest */}
+              {rest.length > 0 && (
+                <div className="md:hidden mt-2 bg-white rounded-2xl shadow-sm overflow-hidden">
+                  {rest.map((film, i) => (
+                    <div
+                      key={film.film_id}
+                      className="flex items-start gap-3 p-4 border-b border-[#262335]/5 last:border-0"
+                      style={{ animation: `fadeUp 0.4s ease ${i * 0.04}s both` }}
+                    >
+                      <span className="flex-shrink-0 w-8 h-8 rounded-full bg-[#262335]/8 text-[#262335]/50 text-xs font-black flex items-center justify-center tabular-nums">
+                        {film.rank}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-black text-[#262335] text-sm uppercase tracking-tight truncate">{film.title}</p>
+                        <p className="text-xs text-[#262335]/50">{film.director}</p>
+                        {film.country && <p className="text-xs text-[#262335]/30">{film.country}</p>}
+                      </div>
+                      <div className="text-right flex-shrink-0">
+                        {film.average_rating !== null ? (
+                          <p className="font-black text-[#463699] text-base">{film.average_rating.toFixed(1)}<span className="text-xs text-[#262335]/30">/10</span></p>
+                        ) : (
+                          <p className="text-xs text-[#262335]/20">—</p>
+                        )}
+                        <p className="text-xs text-[#262335]/30">{film.rating_count} votes</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
This pull request significantly redesigns the `PrizeList` page to provide a more visually engaging and user-friendly presentation of the film ranking results. The changes introduce a podium-style display for the top 3 films, enhanced styling and animations, and improved handling for loading, error, and empty states. The code is also refactored to separate concerns and improve readability.

**UI/UX Improvements:**

* Introduced a podium layout for the top 3 films using the new `PodiumCard` component, with medal emojis, themed colors, and visual elevation for the first place. The rest of the films are displayed in a redesigned table and mobile card layout. [[1]](diffhunk://#diff-801456549fdd12468e6953ae3572ff39e4ecc0445c904dfafae1b24eaf764df1L3-R159) [[2]](diffhunk://#diff-801456549fdd12468e6953ae3572ff39e4ecc0445c904dfafae1b24eaf764df1R184-R330)
* Added the `StarRating` component to visually represent average ratings with a progress bar and improved formatting.
* Enhanced the header, loading, error, and empty states with new styles, icons, and clearer messaging for a more polished user experience.

**Code Structure and Maintainability:**

* Refactored the code by extracting `PodiumCard`, `TableRow`, and `StarRating` into their own components for better readability and separation of concerns.
* Removed the unused `FaTrophy` icon and the old `RANK_STYLES` object, replacing them with the new `MEDAL` configuration for consistent styling.

**Error Handling:**

* Cleaned up error handling by removing unnecessary console logging and ensuring user-facing error messages are displayed appropriately.