### PR TITLE
feat(auth): implement password reset requirement for jury on first login and notify via event

### DIFF
--- a/Front-end/src/App.jsx
+++ b/Front-end/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import RootLayout from "./layouts/RootLayout.jsx";
 import Home from "./pages/Home.jsx";
 import Login from "./pages/Login.jsx";
@@ -49,8 +49,35 @@ const ProtectedRoute = ({ children }) => {
 };
 
 export default function App() {
+  // Détecte si le jury doit changer son mot de passe à la 1ère connexion
+  const checkMustReset = () => {
+    try {
+      const user = JSON.parse(localStorage.getItem("user") || "{}");
+      // Le backend met must_reset_password=true uniquement pour les jurys
+      return user.must_reset_password === true || user.must_reset_password === 1;
+    } catch { return false; }
+  };
+
+  const [mustReset, setMustReset] = useState(checkMustReset);
+
+  // Se déclenche après chaque login (Login.jsx dispatch "auth-change")
+  useEffect(() => {
+    const handler = () => setMustReset(checkMustReset());
+    window.addEventListener("auth-change", handler);
+    return () => window.removeEventListener("auth-change", handler);
+  }, []);
+
+  const handlePasswordChanged = () => {
+    const user = JSON.parse(localStorage.getItem("user") || "{}");
+    localStorage.setItem("user", JSON.stringify({ ...user, must_reset_password: false }));
+    setMustReset(false);
+  };
+
   return (
     <BrowserRouter>
+      {/* Modal bloquante si 1ère connexion jury */}
+      {mustReset && <ChangePassword forceMode onSuccess={handlePasswordChanged} />}
+
       <ScrollToTop />
       <Routes>
         <Route path="login" element={<Login />} />

--- a/Front-end/src/pages/Login.jsx
+++ b/Front-end/src/pages/Login.jsx
@@ -60,6 +60,10 @@ export default function Login() {
       const response = await login(formData);
       console.log("Login successful:", response);
 
+      // Notifie App.jsx pour qu'il affiche la modal si must_reset_password = true
+      // (authService a déjà sauvegardé must_reset_password dans le user du localStorage)
+      window.dispatchEvent(new Event("auth-change"));
+
       // Redirect to profile page based on user role
       const profile = getProfileRoute();
       navigate(profile ? profile.path : "/");

--- a/Front-end/src/services/authService.js
+++ b/Front-end/src/services/authService.js
@@ -58,7 +58,12 @@ export const login = async (credentials) => {
     // Store token and user data if login successful
     if (data.data?.token) {
       localStorage.setItem("token", data.data.token);
-      localStorage.setItem("user", JSON.stringify(data.data.user));
+      // must_reset_password est dans data.data (retourné par le login controller)
+      const mustReset = data.data.must_reset_password === true;
+      localStorage.setItem("user", JSON.stringify({
+        ...data.data.user,
+        must_reset_password: mustReset,
+      }));
     }
 
     return data;

--- a/back-end/src/controllers/admin.controller.js
+++ b/back-end/src/controllers/admin.controller.js
@@ -2,6 +2,7 @@ import pool from "../config/database.js";
 import bcrypt from "bcryptjs";
 import Film from "../models/Film.js";
 import { canChangeFilmStatus } from "../services/filmStatus.service.js";
+import { sendJuryWelcome } from "../services/email.service.js";
 
 // ─── USERS ──────────────────────────────────────────────────
 
@@ -51,18 +52,29 @@ export const createUser = async (req, res) => {
     }
 
     const hashed = await bcrypt.hash(password, 10);
+    const roleList = Array.isArray(roles) && roles.length > 0 ? roles : [1];
+    const isJury = roleList.includes(1);
+
+    // Si c'est un jury, forcer le changement de mot de passe à la 1ère connexion
     const [result] = await pool.query(
-      "INSERT INTO users (name, email, password, created_at) VALUES (?, ?, ?, NOW())",
-      [name, email, hashed]
+      "INSERT INTO users (name, email, password, must_reset_password, created_at) VALUES (?, ?, ?, ?, NOW())",
+      [name, email, hashed, isJury ? 1 : 0]
     );
 
     const userId = result.insertId;
 
-    const roleList = Array.isArray(roles) && roles.length > 0 ? roles : [1];
     for (const roleId of roleList) {
       await pool.query(
         "INSERT INTO user_roles (user_id, role_id) VALUES (?, ?)",
         [userId, roleId]
+      );
+    }
+
+    // Si c'est un jury, créer l'entrée jury_members + envoyer l'email de bienvenue
+    if (isJury) {
+      await pool.query("INSERT INTO jury_members (user_id) VALUES (?)", [userId]).catch(() => {});
+      sendJuryWelcome({ to: email, name, password, lang: req.body.lang || "fr" }).catch((err) =>
+        console.error("[Email] Erreur envoi jury welcome:", err)
       );
     }
 

--- a/back-end/src/services/email.service.js
+++ b/back-end/src/services/email.service.js
@@ -3,6 +3,14 @@ import { Resend } from "resend";
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const FROM = process.env.RESEND_FROM || "onboarding@resend.dev";
+
+// En dev, redirige tous les emails vers cette adresse (domaine non vérifié Resend)
+const DEV_RECIPIENT = process.env.RESEND_DEV_RECIPIENT || null;
+const to_ = (email) => {
+  const resolved = DEV_RECIPIENT || email;
+  console.log("[Resend] to_ resolved:", JSON.stringify(resolved), "| DEV_RECIPIENT:", JSON.stringify(DEV_RECIPIENT), "| original:", JSON.stringify(email));
+  return resolved;
+};
 const APP_NAME = "MarsAI Festival";
 const APP_URL = process.env.FRONTEND_URL || "http://localhost:5173";
 
@@ -92,7 +100,7 @@ export async function sendJuryWelcome({ to, name, password, lang = "fr" }) {
   console.log("[Resend] FROM:", FROM);
   const result = await resend.emails.send({
     from: FROM,
-    to,
+    to: to_(to),
     subject: isFr ? `🎬 Vos accès jury — ${APP_NAME}` : `🎬 Your jury access — ${APP_NAME}`,
     html: baseTemplate(content, lang),
   });
@@ -129,7 +137,7 @@ export async function sendPasswordReset({ to, name, token, lang = "fr" }) {
   console.log("[Resend] API Key set:", !!process.env.RESEND_API_KEY);
   const result = await resend.emails.send({
     from: FROM,
-    to,
+    to: to_(to),
     subject: isFr ? `🔐 Réinitialisation de mot de passe — ${APP_NAME}` : `🔐 Password reset — ${APP_NAME}`,
     html: baseTemplate(content, lang),
   });
@@ -159,7 +167,7 @@ export async function sendNewsletterConfirmation({ to, token, lang = "fr" }) {
   console.log("[Resend] Sending newsletter confirm to:", to);
   const result = await resend.emails.send({
     from: FROM,
-    to,
+    to: to_(to),
     subject: isFr ? `✅ Confirmez votre inscription — ${APP_NAME}` : `✅ Confirm your subscription — ${APP_NAME}`,
     html: baseTemplate(content, lang),
   });


### PR DESCRIPTION
This pull request implements a "force password reset on first login" feature for jury users and adds improvements to email handling in development. The most significant changes include enforcing password reset for juries, updating the login flow to trigger this requirement, and ensuring all outgoing emails are redirected to a development address when configured.

**Force password reset for jury users:**
- When an admin creates a jury user, the backend now sets the `must_reset_password` flag in the `users` table. On first login, the front-end detects this flag and blocks access with a modal requiring a password change. Once changed, the flag is cleared in both local storage and the UI. [[1]](diffhunk://#diff-d5328ab764e93cf3a0320ba77b65da3f8f1d32fb3a614782e2a9f988a7bda067R55-R80) [[2]](diffhunk://#diff-35630dc51fbe7ee9e37fbc2d397b8ae66498019d5abcee2159e98cbd00ccf6e8R52-R80) [[3]](diffhunk://#diff-a5760508acf90a6a1b53e6403888e8fe01181ec9bedcc212940c65f67a90946aL61-R66)

**Login and authentication flow updates:**
- After a successful login, the front-end dispatches an `auth-change` event. The main app listens for this event to show the password reset modal if needed, ensuring the UI stays in sync with authentication state. [[1]](diffhunk://#diff-fec490d6843c7b436ba5b38266a356ca255d9e1a0b0db7c32a4903487d3e3cb4R63-R66) [[2]](diffhunk://#diff-35630dc51fbe7ee9e37fbc2d397b8ae66498019d5abcee2159e98cbd00ccf6e8R52-R80)

**Email handling improvements (development environment):**
- All outgoing emails are now routed to a development recipient address if `RESEND_DEV_RECIPIENT` is set, preventing accidental emails to real users during development. This affects jury welcome, password reset, and newsletter confirmation emails. [[1]](diffhunk://#diff-2809ad4d993b131e7db6277f056993541067475f2814d904a7f8439f2c08192fR6-R13) [[2]](diffhunk://#diff-2809ad4d993b131e7db6277f056993541067475f2814d904a7f8439f2c08192fL95-R103) [[3]](diffhunk://#diff-2809ad4d993b131e7db6277f056993541067475f2814d904a7f8439f2c08192fL132-R140) [[4]](diffhunk://#diff-2809ad4d993b131e7db6277f056993541067475f2814d904a7f8439f2c08192fL162-R170)

**Jury onboarding automation:**
- When creating a jury user, the backend also inserts a record into the `jury_members` table and sends a welcome email with credentials. Errors in email sending are logged but do not block user creation.

**Front-end dependency update:**
- The front-end now imports `useState` from React in `App.jsx` to support the new modal state logic.